### PR TITLE
Ensure proper linking of ncurses lib with LDFLAGS

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,3 @@
 {erl_opts, [debug_info]}.
 {port_specs, [{"priv/cecho.so", ["c_src/cecho.c"]}]}.
+{port_envs, [{"LDFLAGS", "$LDFLAGS -lncurses"}]}.


### PR DESCRIPTION
This fix fixes "undefined symbol" when loading driver after it has been compiled on Ubuntu and Erlang R15B
