### PR TITLE
Overflow

### DIFF
--- a/c_src/cecho.c
+++ b/c_src/cecho.c
@@ -224,11 +224,18 @@ void do_addch(state *st) {
 void do_addstr(state *st) {
   int arity;
   long strlen;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen+1];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, addnstr(str, strlen));
+  code = addnstr(str, strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_move(state *st) {
@@ -340,13 +347,20 @@ void do_mvaddch(state *st) {
 void do_mvaddstr(state *st) {
   int arity;
   long strlen, y, x;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &y);
   ei_decode_long(st->args, &(st->index), &x);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen+1];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, mvaddnstr((int)y, (int)x, str, (int)strlen));
+  code = mvaddnstr((int)y, (int)x, str, (int)strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_newwin(state *st) {
@@ -393,12 +407,19 @@ void do_wmove(state *st) {
 void do_waddstr(state *st) {
   int arity;
   long slot, strlen;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &slot);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen+1];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, waddnstr(st->win[slot], str, strlen));
+  code = waddnstr(st->win[slot], str, strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_waddch(state *st) {
@@ -414,14 +435,21 @@ void do_waddch(state *st) {
 void do_mvwaddstr(state *st) {
   int arity;
   long slot, y, x, strlen;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &slot);
   ei_decode_long(st->args, &(st->index), &y);
   ei_decode_long(st->args, &(st->index), &x);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen+1];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, mvwaddnstr(st->win[slot], (int)y, (int)x, str, strlen));
+  code = mvwaddnstr(st->win[slot], (int)y, (int)x, str, strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_mvwaddch(state *st) {

--- a/c_src/cecho.c
+++ b/c_src/cecho.c
@@ -226,7 +226,7 @@ void do_addstr(state *st) {
   long strlen;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  char str[strlen+1];
   ei_decode_string(st->args, &(st->index), str);
   encode_ok_reply(st, addnstr(str, strlen));
 }
@@ -344,7 +344,7 @@ void do_mvaddstr(state *st) {
   ei_decode_long(st->args, &(st->index), &y);
   ei_decode_long(st->args, &(st->index), &x);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  char str[strlen+1];
   ei_decode_string(st->args, &(st->index), str);
   encode_ok_reply(st, mvaddnstr((int)y, (int)x, str, (int)strlen));
 }
@@ -396,7 +396,7 @@ void do_waddstr(state *st) {
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &slot);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  char str[strlen+1];
   ei_decode_string(st->args, &(st->index), str);
   encode_ok_reply(st, waddnstr(st->win[slot], str, strlen));
 }
@@ -419,7 +419,7 @@ void do_mvwaddstr(state *st) {
   ei_decode_long(st->args, &(st->index), &y);
   ei_decode_long(st->args, &(st->index), &x);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  char str[strlen+1];
   ei_decode_string(st->args, &(st->index), str);
   encode_ok_reply(st, mvwaddnstr(st->win[slot], (int)y, (int)x, str, strlen));
 }


### PR DESCRIPTION
Hey Mazen, this is the same set of patches I sent you about a year ago.

I've split them so you can just pull in the fix for the ei_decode_string() usage.

The fix for the stack overflow still uses malloc/free. Alternatively, the patch could check the size of the string and return an error, if the string is too large (no idea what a good size for that would be).
