### PR TITLE
Add missing properties for systools

### DIFF
--- a/ebin/cecho.app
+++ b/ebin/cecho.app
@@ -3,4 +3,6 @@
   {vsn, "0.0.3"},
   {modules, [cecho, cecho_srv, cecho_example]},
   {env, []},
+  {applications, []},
+  {registered, []},
   {mod, {cecho, []}}]}.


### PR DESCRIPTION
When using OTP tools (systools) to build application release the following error occurs:

`Missing parameter in .app file: registered`

Adding the `registered` and `applications` properties to the cecho.app file fixes this.