### PR TITLE
Fix deprecations

### DIFF
--- a/c_src/cecho.c
+++ b/c_src/cecho.c
@@ -226,11 +226,18 @@ void do_addch(state *st) {
 void do_addstr(state *st) {
   int arity;
   long strlen;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, addnstr(str, strlen));
+  code = addnstr(str, strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_move(state *st) {
@@ -280,6 +287,7 @@ void do_has_colors(state *st) {
 }
 
 void do_start_color(state *st) {
+  use_default_colors();
   encode_ok_reply(st, start_color());
 }
 
@@ -342,13 +350,20 @@ void do_mvaddch(state *st) {
 void do_mvaddstr(state *st) {
   int arity;
   long strlen, y, x;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &y);
   ei_decode_long(st->args, &(st->index), &x);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, mvaddnstr((int)y, (int)x, str, (int)strlen));
+  code = mvaddnstr((int)y, (int)x, str, (int)strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_newwin(state *st) {
@@ -395,12 +410,19 @@ void do_wmove(state *st) {
 void do_waddstr(state *st) {
   int arity;
   long slot, strlen;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &slot);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, waddnstr(st->win[slot], str, strlen));
+  code = waddnstr(st->win[slot], str, strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_waddch(state *st) {
@@ -416,14 +438,21 @@ void do_waddch(state *st) {
 void do_mvwaddstr(state *st) {
   int arity;
   long slot, y, x, strlen;
+  char *str = NULL;
+  int code = 0;
   ei_decode_tuple_header(st->args, &(st->index), &arity);
   ei_decode_long(st->args, &(st->index), &slot);
   ei_decode_long(st->args, &(st->index), &y);
   ei_decode_long(st->args, &(st->index), &x);
   ei_decode_long(st->args, &(st->index), &strlen);
-  char str[strlen];
+  if ( (str = calloc(strlen+1, 1)) == NULL) {
+      encode_ok_reply(st, ENOMEM);
+      return;
+  }
   ei_decode_string(st->args, &(st->index), str);
-  encode_ok_reply(st, mvwaddnstr(st->win[slot], (int)y, (int)x, str, strlen));
+  code = mvwaddnstr(st->win[slot], (int)y, (int)x, str, strlen);
+  free(str);
+  encode_ok_reply(st, code);
 }
 
 void do_mvwaddch(state *st) {

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info,
+            {platform_define, "^(R14|R15|R16B|17)", 'random_module_available'}
+           ]}.
 
 {port_specs, [{"priv/cecho.so", ["c_src/cecho.c"]}]}.
 

--- a/src/cecho.app.src
+++ b/src/cecho.app.src
@@ -1,6 +1,6 @@
 {application, cecho,
  [{description, "An ncurses library for Erlang"},
-  {vsn, "0.0.4"},
+  {vsn, "0.5.0"},
   {registered, []},
   {mod, { cecho, []}},
   {applications,

--- a/src/cecho_example.erl
+++ b/src/cecho_example.erl
@@ -127,8 +127,7 @@ colors() ->
     ok = cecho:init_pair(6, ?ceCOLOR_BLACK, ?ceCOLOR_CYAN),
     ok = cecho:init_pair(7, ?ceCOLOR_BLACK, ?ceCOLOR_WHITE),
     ok = cecho:init_pair(8, ?ceCOLOR_BLACK, ?ceCOLOR_BLACK),
-    {A, B, C} = erlang:now(),
-    random:seed(A, B, C),
+    rand_seed(),
     {MaxRow, MaxCol} = cecho:getmaxyx(),
     cecho:move(10,10),
     cecho:addstr(io_lib:format("Max Row: ~p, Max Col: ~p",[MaxRow, MaxCol])),
@@ -154,14 +153,26 @@ do_colors(MR,MC,N) ->
 
 ch_colors(_,_,0) -> ok;
 ch_colors(MR, MC, N) ->
-    R = random:uniform(MR)-1,
-    C = random:uniform(MC)-1,
-    CN = random:uniform(8),
+    R = rand_uniform(MR)-1,
+    C = rand_uniform(MC)-1,
+    CN = rand_uniform(8),
     cecho:attron(?ceCOLOR_PAIR(CN)),
     cecho:move(R, C),
     cecho:addch($ ),
     cecho:move(R, C),
     ch_colors(MR, MC, N-1).
+
+-ifdef(random_module_available).
+rand_seed() ->
+  random:seed(os:timestamp()).
+rand_uniform(N) ->
+  random:uniform(N).
+-else.
+rand_seed() ->
+  ok.
+rand_uniform(N) ->
+  rand:uniform(N).
+-endif.
 
 %%
 %% Simply puts an @ character somewhere. If you go out of bounds you crash


### PR DESCRIPTION
This was mostly done to fix the erlang:now/0 deprecation warning with erlang 18+, but I thought it might be useful to just add in the other open pull requests.  So if you merge this one (and hopefully add a 0.5.0 tag), you can close all open pull requests on this project.  Alternatively, add me as a contributor and I will do it all.