### PR TITLE
Removed some unnecessary files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-*.beam
-priv/*.so
-priv/lib/*
+.rebar3
+ebin
+priv
 c_src/*.o
 _build
 rebar.lock

--- a/rebar.config
+++ b/rebar.config
@@ -11,4 +11,5 @@
    {"(freebsd)", compile, "gmake -C c_src"}]}.
 {post_hooks,
   [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
-   {"(freebsd)", clean, "gmake -C c_src clean"}]}.
+   {"(freebsd)", clean, "gmake -C c_src clean"},
+   {clean, "rm -rf ebin priv"}]}.

--- a/src/cecho.app.src
+++ b/src/cecho.app.src
@@ -1,6 +1,6 @@
 {application, cecho,
  [{description, "An ncurses library for Erlang"},
-  {vsn, "0.5.0"},
+  {vsn, "0.5.1"},
   {registered, []},
   {mod, { cecho, []}},
   {applications,


### PR DESCRIPTION
The .empty file was not necessary as rebar3 will create the priv
directory for you.  It's existence was causing me some issues when
I was packaging this as an RPM using epm.  This change removes the
.empty file and the priv directory, it also adds ebin and priv
directories to the .gitignore, and removes them when you run rebar3
clean. I bumped the version to 0.5.1.  @mazenharake if you have no issues,
please merge and tag with 0.5.1.  Thanks!