### PR TITLE
fix(port-compiler): use unpinned pc as recommended in rebar3 docs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,7 @@
 {erl_opts, [debug_info,
             {platform_define, "^(R14|R15|R16B|17)", 'random_module_available'}
            ]}.
-{plugins, [
-            { pc, {git, "git@github.com:blt/port_compiler.git", {tag, "1.6.0"}}}
-          ]}.
+{plugins, [pc]}.
 {port_specs, [{"priv/cecho.so", ["c_src/cecho.c"]}]}.
 {port_env, [
              {"DRV_LDFLAGS", "$DRV_LDFLAGS -lncurses"}


### PR DESCRIPTION
This issue bit me when I was building [entop](https://github.com/mazenharake/entop) tool via `rebar3` on a Debian 9 machine:
```
rebar3 compile
===> Verifying dependencies...
===> Fetching cecho ({git,"https://github.com/mazenharake/cecho.git",
                                 {tag,"0.5.2"}})
===> Fetching pc ({git,"git@github.com:blt/port_compiler.git",
                              {tag,"1.6.0"}})
===> Plugin {pc,{git,"git@github.com:blt/port_compiler.git",
                            {tag,"1.6.0"}}} not available. It will not be used.
===> Compiling cecho
```
`cecho` is one of its dependencies and for some (not obvious to me) reason it pins `port-compiler` plugin version. According to `rebar3` docs this is [not recommended](https://www.rebar3.org/docs/using-available-plugins#section-port-compiler) and unpinned pc should be used. After this change everything works perfectly:
```
rebar3 compile
===> Verifying dependencies...
===> Fetching cecho ({git,"https://github.com/AlexanderKaraberov/cecho.git",
                                 {tag,"0.5.3"}})
===> Fetching pc ({pkg,<<"pc">>,<<"1.10.0">>})
===> Downloaded package, caching at /home/node/.cache/rebar3/hex/default/packages/pc-1.10.0.tar
===> Compiling pc
===> Compiling cecho
```