### PR TITLE
use https instead of git

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
             {platform_define, "^(R14|R15|R16B|17)", 'random_module_available'}
            ]}.
 {plugins, [
-            { pc, {git, "git@github.com:blt/port_compiler.git", {tag, "1.6.0"}}}
+            { pc, {git, "https://github.com/blt/port_compiler.git", {tag, "1.6.0"}}}
           ]}.
 {port_specs, [{"priv/cecho.so", ["c_src/cecho.c"]}]}.
 {port_env, [


### PR DESCRIPTION
not every build env contains github ssh key
maybe https://github.com/blt/port_compiler.git is better than git@github.com:blt/port_compiler.git