### PR TITLE
Detach on endwin

### DIFF
--- a/include/cecho.hrl
+++ b/include/cecho.hrl
@@ -91,6 +91,7 @@
 -define(ceKEY_LEFT, 260).
 -define(ceKEY_RIGHT, 261).
 -define(ceKEY_HOME, 262).
+-define(ceKEY_BACKSPACE, 263).
 -define(ceKEY_F(N), 264+N).
 -define(ceKEY_DEL, 330).
 -define(ceKEY_INS, 331).

--- a/src/cecho.erl
+++ b/src/cecho.erl
@@ -43,7 +43,8 @@
 	 scrollok/2, mvaddch/3, mvaddstr/3, newwin/4, delwin/1, wmove/3,
 	 waddstr/2, waddch/2, mvwaddstr/4, mvwaddch/4, wrefresh/1, hline/2,
 	 whline/3, vline/2, wvline/3, border/8, wborder/9, box/3, getyx/1,
-	 getmaxyx/1, attron/2, attroff/2, keypad/2, getch/0, touchwin/1]).
+	 getmaxyx/1, attron/2, attroff/2, keypad/2, getch/0, touchwin/1,
+         endwin/0]).
 
 %% =============================================================================
 %% Application API
@@ -201,6 +202,9 @@ touchwin(Window) when is_integer(Window) ->
 
 getch() ->
     cecho_srv:getch().
+
+endwin() ->
+    call(?ENDWIN).
 
 %% =============================================================================
 %% Behaviour Callbacks


### PR DESCRIPTION
Hello,

I am working on an Erlang application using cecho and trying to design an UI that can switch to an external VIM editor under certain conditions. When doing this “naively” it seems that the stdin becomes shared between Erlang and the editor causing some characters to appear in the editor (and presumably others arriving at the Erlang side). This is not very practcal, hence I tried to find out how to work around this.

My suggested workaround for this is to add some additional code to the C-part of cecho to detach from the stdin whenever `endwin()` is called. This allows external applications to take control of the Terminal e.g. as follows

```erlang
launch_vim() ->
	cecho:endwin(),
	Port = open_port({spawn_executable, "/usr/bin/vim"},
						[nouse_stdio, exit_status]),
	receive
	{Port, {exit_status, _RC}} ->
		cecho:refresh()
	end.
```

I would love to get some feedback on this idea and whether it could have a chance to become part of the upstream cecho repository? If not, is there any alternative design that can be pursued to solve this issue wrt. starting an exteranl curses application from within a cecho-enabled Erlang application?

Additionally, I had some use of an additional ceKEY_BACKSPACE definition which I have added as a separate commit. It is unrelated but may also be useful for other users to have as a definition in the upstream?

Thanks in advance
Linux-Fan (@m7a)