### PR TITLE
Enable support for SIGWINCH reporting through ceKEY_RESIZE

### DIFF
--- a/c_src/cecho.c
+++ b/c_src/cecho.c
@@ -27,6 +27,7 @@
 // Includes
 #include <stdlib.h>
 #include <string.h>
+#include <sys/ioctl.h>
 #include "cecho.h"
 #include "cecho_commands.h"
 #include "erl_driver.h"
@@ -296,7 +297,18 @@ void do_getmaxyx(state *st) {
   long slot;
   int x, y;
   ei_decode_long(st->args, &(st->index), &slot);
-  getmaxyx(st->win[slot], y, x);
+  if (slot == 0) {
+    struct winsize w;
+    int rc = ioctl(0, TIOCGWINSZ, &w);
+    if (rc == 0) {
+      y = w.ws_row;
+      x = w.ws_col;
+    } else {
+      getmaxyx(st->win[slot], y, x);
+    }
+  } else {
+    getmaxyx(st->win[slot], y, x);
+  }
   tuple(&(st->eixb), 2);
   integer(&(st->eixb), y);
   integer(&(st->eixb), x);

--- a/include/cecho.hrl
+++ b/include/cecho.hrl
@@ -99,4 +99,4 @@
 -define(ceKEY_PGUP, 339).
 -define(ceKEY_END, 360).
 
-
+-define(ceKEY_RESIZE, 410).


### PR DESCRIPTION
Previously, window resizing was reported to the applications through the opaque key code 410. Also, occasionally, the reported window size was wrong.

This commit attempts to fix this by adding a new constant `ceKEY_RESIZE` to detect the virtual key reported by NCurses for resize events. Also, the code is extended to explicitly query the current window size via `ioctl`.

*I am not sure if this is the right solution, but it seems to be an improvement over the state from before hence I submit it for your consideration :smile:*